### PR TITLE
Messages are always UTF-8 encoded.

### DIFF
--- a/tornadio/polling.py
+++ b/tornadio/polling.py
@@ -235,7 +235,7 @@ class TornadioXHRMultipartSocketHandler(TornadioPollingHandlerBase):
 
     def data_available(self, raw_data):
         self.preflight()
-        self.write("Content-Type: text/plain; charset=us-ascii\n\n")
+        self.write("Content-Type: text/plain; charset=UTF-8\n\n")
         self.write(raw_data + '\n')
         self.write('--socketio\n')
         self.flush()


### PR DESCRIPTION
Hi!

I am somehow unsure about this since it is my very first project using socket.io and tornad.io. Basically I am experiencing encoding problems when using Firefox 4. I noticed, that it was using the xhr-multipart transport, whereas Chrome was using xhr-polling. The polling transport worked fine, but multipart broke my umlauts. Using this commit it worked, but I am quite unsure if this is correct at all.

Maybe you can double check this and link me to some more documentation...???

What I have found out is that all str/unicode objects are "encoded" to "UTF-8" but in the xhr-multipart transport you write a content-type line saying it is 'us-ascii'.
