### PR TITLE
fix for being able use latest tornado

### DIFF
--- a/tornadio/router.py
+++ b/tornadio/router.py
@@ -137,12 +137,12 @@ class SocketRouterBase(RequestHandler):
         else:
             extra_re = "(?P<extra>)"
 
-        proto_re = "(%s)" % "|".join(PROTOCOLS.keys())
+        proto_re = "|".join(PROTOCOLS.keys())
 
         cls._route = (r"/(?P<resource>%s)%s/"
                       "(?P<protocol>%s)/?"
                       "(?P<session_id>[0-9a-zA-Z]*)/?"
-                      "((?P<protocol_init>\d*?)|(?P<xhr_path>\w*?))/?"
+                      "(?P<protocol_init>\d*?)|(?P<xhr_path>\w*?)/?"
                       "(?P<jsonp_index>\d*?)" % (resource,
                                                  extra_re,
                                                  proto_re),


### PR DESCRIPTION
This hack is based on this discussion with Ben
https://groups.google.com/d/topic/python-tornado/eWH4AZVdA60/discussion

Basically, the handler URLspec that tornadio registers contains double-matchers. 
E.g.

``` python
((?P<protocol_init>\d*?)|(?P<xhr_path>\w*?))/?
```

instead of 

``` python
((?P<protocol_init>\d*?)|(?P<xhr_path>\w*?))/?
```

tornado doesn't like it. The number of groups is more than the number of named keywords. 
I've only tried this patch with FlashSocket and WebSocket and with the latest tornado. 
