### PR TITLE
Encoding problems in Firefox while using xhr-multipart

### DIFF
--- a/tornadio/polling.py
+++ b/tornadio/polling.py
@@ -169,7 +169,7 @@ class TornadioXHRPollingSocketHandler(TornadioPollingHandlerBase):
 
         self.async_callback(self.session.raw_message)(data)
 
-        self.set_header('Content-Type', 'text/plain')
+        self.set_header('Content-Type', 'text/plain; charset=UTF-8')
         self.write('ok')
         self.finish()
 
@@ -183,8 +183,8 @@ class TornadioXHRPollingSocketHandler(TornadioPollingHandlerBase):
 
     def data_available(self, raw_data):
         self.preflight()
-        self.set_header("Content-Type", "text/plain; charset=UTF-8")
-        self.set_header("Content-Length", len(raw_data))
+        self.set_header('Content-Type', 'text/plain; charset=UTF-8')
+        self.set_header('Content-Length', len(raw_data))
         self.write(raw_data)
         self.finish()
 
@@ -206,7 +206,7 @@ class TornadioXHRMultipartSocketHandler(TornadioPollingHandlerBase):
             raise HTTPError(401, 'Forbidden')
 
         self.set_header('Content-Type',
-                        'multipart/x-mixed-replace;boundary="socketio"')
+                        'multipart/x-mixed-replace;boundary="socketio; charset=UTF-8"')
         self.set_header('Connection', 'keep-alive')
         self.write('--socketio\n')
 
@@ -224,7 +224,7 @@ class TornadioXHRMultipartSocketHandler(TornadioPollingHandlerBase):
         data = self.get_argument('data')
         self.async_callback(self.session.raw_message)(data)
 
-        self.set_header('Content-Type', 'text/plain')
+        self.set_header('Content-Type', 'text/plain; charset=UTF-8')
         self.write('ok')
         self.finish()
 
@@ -255,7 +255,7 @@ class TornadioHtmlFileSocketHandler(TornadioPollingHandlerBase):
         if not self.session.set_handler(self):
             raise HTTPError(401, 'Forbidden')
 
-        self.set_header('Content-Type', 'text/html')
+        self.set_header('Content-Type', 'text/html; charset=UTF-8')
         self.set_header('Connection', 'keep-alive')
         self.set_header('Transfer-Encoding', 'chunked')
         self.write('<html><body>%s' % (' ' * 244))
@@ -274,7 +274,7 @@ class TornadioHtmlFileSocketHandler(TornadioPollingHandlerBase):
         data = self.get_argument('data')
         self.async_callback(self.session.raw_message)(data)
 
-        self.set_header('Content-Type', 'text/plain')
+        self.set_header('Content-Type', 'text/plain; charset=UTF-8')
         self.write('ok')
         self.finish()
 


### PR DESCRIPTION
Hi!

First of all, thanks for developing tornadio. Its working really nice for me.

I'm having an issue in Firefox while using xhr-multipart. Messages were being sent as UTF-8 and read as ISO8869-1.

Adding the correct headers fixed the issue. Don't know if it's the better way to fix this problem, but it's working for me.

Again, thanks for your great work!

Marcos
