### PR TITLE
Stopped heartbeats on connection close to prevent IOErrors.

### DIFF
--- a/tornadio/conn.py
+++ b/tornadio/conn.py
@@ -79,7 +79,9 @@ class SocketConnection(object):
         self._protocol.send(message)
 
     def close(self):
-        """Focibly close client connection"""
+        """Focibly close client connection.
+        Stop heartbeats as well, as they would cause IOErrors once the connection is closed."""
+        self.stop_heartbeat()
         self._protocol.close()
 
     def raw_message(self, message):


### PR DESCRIPTION
If calling `self.close()` from within a socket handler, I've found that IOErrors can sometimes occur due to heartbeats being sent through a closed connection. I've added a `self.stop_heartbeat()` to the built-in `close()` handler to prevent this issue. (Although it could be a very rare edge case, or just me doing something wrong, as well!)
