### PR TITLE
Prevent heartbeat leak when connection closed inside heartbeat callback

### DIFF
--- a/tornadio/periodic.py
+++ b/tornadio/periodic.py
@@ -45,4 +45,5 @@ class Callback(object):
         except:
             logging.error("Error in periodic callback", exc_info=True)
 
-        self.start(next_call)
+        if self._running:
+            self.start(next_call)


### PR DESCRIPTION
Whenever SocketConnection.close (and thus stop_heartbeat) is called from within _heartbeat -- either explicitly or due to an IOError -- the periodic callback will happily ignore this and schedule the next heartbeat. This causes a subtle memory and callback leak, which clogs up the IOLoop and negatively impacts performance.

This is easily prevented by checking the _running flag right before rescheduling the periodic callback.
