### PR TITLE
Auto start param for Socket Server

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -187,6 +187,14 @@ To start it, do following (assuming you created application object before)::
 
 SocketServer will automatically start Flash policy server, if required.
 
+SocketServer by default will also automatically start ioloop. In order to prevent this behaviour and perform some additional action after socket server is created you can use auto_start param. In this case you should start ioloop manually.
+
+  if __name__ == "__main__":
+    socketio_server = SocketServer(application, auto_start=False)
+    logging.info('You can perform some actions here')
+    ioloop.IOLoop.instance().start()
+
+
 Going big
 ---------
 

--- a/README.rst
+++ b/README.rst
@@ -187,11 +187,11 @@ To start it, do following (assuming you created application object before)::
 
 SocketServer will automatically start Flash policy server, if required.
 
-SocketServer by default will also automatically start ioloop. In order to prevent this behaviour and perform some additional action after socket server is created you can use auto_start param. In this case you should start ioloop manually.
+SocketServer by default will also automatically start ioloop. In order to prevent this behaviour and perform some additional action after socket server is created you can use auto_start param. In this case you should start ioloop manually::
 
   if __name__ == "__main__":
     socketio_server = SocketServer(application, auto_start=False)
-    logging.info('You can perform some actions here')
+    logging.info('You can perform some actions here')    
     ioloop.IOLoop.instance().start()
 
 

--- a/tornadio/server.py
+++ b/tornadio/server.py
@@ -70,7 +70,7 @@ class SocketServer(HTTPServer):
 
         # Set auto_start to False in order to have opportunities 
         # to work with server object and/or perform some actions 
-        # after server already created but before ioloop will start.
+        # after server is already created but before ioloop will start.
         # Attention: if you use auto_start param set to False 
         # you should start ioloop manually
         if auto_start:

--- a/tornadio/server.py
+++ b/tornadio/server.py
@@ -25,7 +25,8 @@ class SocketServer(HTTPServer):
 
     def __init__(self, application,
                  no_keep_alive=False, io_loop=None,
-                 xheaders=False, ssl_options=None
+                 xheaders=False, ssl_options=None, 
+                 auto_start=True
                  ):
         """Initializes the server with the given request callback.
 
@@ -67,5 +68,9 @@ class SocketServer(HTTPServer):
             except Exception, ex:
                 logging.error('Failed to start Flash policy server: %s', ex)
 
-        logging.info('Entering IOLoop...')
-        io_loop.start()
+        # Set auto_start to False in order to have opportunities 
+        # to work with server object and/or perform some actions 
+        # after server already created but before ioloop will start 
+        if auto_start:
+            logging.info('Entering IOLoop...')
+            io_loop.start()

--- a/tornadio/server.py
+++ b/tornadio/server.py
@@ -70,7 +70,9 @@ class SocketServer(HTTPServer):
 
         # Set auto_start to False in order to have opportunities 
         # to work with server object and/or perform some actions 
-        # after server already created but before ioloop will start 
+        # after server already created but before ioloop will start.
+        # Attention: if you use auto_start param set to False 
+        # you should start ioloop manually
         if auto_start:
             logging.info('Entering IOLoop...')
             io_loop.start()


### PR DESCRIPTION
Starting ioloop within **init** method of SocketServer is not always suitable way. Auto_start parameter stores default behavior the same, but provide additional opportunities to perform some additional actions after socket server is created.
