### PR TITLE
fix for cross site authentication

### DIFF
--- a/tornadio/polling.py
+++ b/tornadio/polling.py
@@ -96,8 +96,7 @@ class TornadioPollingHandlerBase(RequestHandler):
                 self.set_header('Access-Control-Allow-Origin',
                                 self.request.headers['Origin'])
 
-                if self.request.headers.has_key('Cookie'):
-                    self.set_header('Access-Control-Allow-Credentials', True)
+                self.set_header('Access-Control-Allow-Credentials', 'true')
 
                 return True
             else:


### PR DESCRIPTION
When using xhr transports, "cookie" may not already be in headers for preflight request. 
If request needs cookies to be set/sent, that check will result in 'Access-Control-Allow-Credentials' not being set.

Also, at least in Chrome/Firefox, setting header to value of True will result in it not being detected properly and you'll get a `Credentials flag is true, but Access-Control-Allow-Credentials is not "true"` error. 'Access-Control-Allow-Credentials' needs to be set to 'true'

reference https://github.com/LearnBoost/socket.io-client/pull/335
